### PR TITLE
Issue/17 fix timezone issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4 - 11/01/2022
+- Fixed time-zone awareness issues in test cases (#17)
+
 ## 1.0.3 - 10/01/2022
 - Renamed test lab config's environment variables (inmanta/infra-tickets#151)
 

--- a/module.yml
+++ b/module.yml
@@ -4,5 +4,5 @@ description:
 license: ASL 2.0
 copyright: 2021 Inmanta
 name: terraform
-version: 1.0.3
+version: 1.0.4
 compiler_version: 2019.3


### PR DESCRIPTION
# Description

The helper to get actions from the server wasn't compatible with older version of the orchestrator (if the orchestrator or the client was still using timezone unaware `datetime` objects).

This is now fixed.

Closes #17 