### PR TITLE
Issue/composable config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0 - 20/06/2022
+- Add support for model based config entity tree (for generated modules).
+
 ## 1.1.0 - 16/06/2022
 - Decouple the terraform provider client sdk from the inmanta handler logic.
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import std
+import terraform::config
 
 entity Provider:
     """
@@ -27,6 +28,9 @@ entity Provider:
     :attr alias: An alias to differentiate this provider from other providers with the same binary 
         but different config
     :attr config: The config to apply to this provider
+    :attr manual_config: Whether the user wishes to provide the config as a dict, if false
+        the config should be provided as a config block entity tree via the root_config
+        relation.
     :attr auto_agent: Whether to start an agent automatically or not.  If set to false
         the relation agent_config should be set manually.
     :rel agent_config: This needs to be set only if auto_agent=false
@@ -36,13 +40,20 @@ entity Provider:
     string version = "latest"
     string alias = ""
     dict config
+    bool manual_config = true
 
     bool auto_agent=true
 end
+
 Provider.agent_config [1] -- std::AgentConfig
+"""Relation to the agent config"""
+
+Provider.root_config [0:1] -- terraform::config::Block
+"""Relation to the root configuration, or null if manual_config is true"""
+
 index Provider(namespace, type, version, alias)
 
-implement Provider using std::none
+implement Provider using providerConfig
 implement Provider using agentConfig when auto_agent
 
 implementation agentConfig for Provider:
@@ -54,6 +65,21 @@ implementation agentConfig for Provider:
     )
 end
 
+implementation providerConfig for Provider:
+    """
+    If self.manual_config is true, the user should provide the config as a dict
+    directly to the entity.  The root_config relation should then be set to null.
+    If self.manual_config is false, the user should provide the root_config
+    relation, the Block entity will be serialized and attached to this entity
+    config attribute.
+    """
+    if self.manual_config:
+        self.root_config = null
+    else:
+        self.config = self.root_config._config
+    end
+end
+
 entity Resource extends std::PurgeableResource:
     """
     A Terraform resource
@@ -61,6 +87,9 @@ entity Resource extends std::PurgeableResource:
     :attr type: The type of resource this is
     :attr name: An arbitrary name to identify this resource
     :attr config: The configuration for this resource
+    :attr manual_config: Whether the user wishes to provide the config as a dict, if false
+        the config should be provided as a config block entity tree via the root_config
+        relation.
     :attr terraform_id: If this is set, and the resource state is not stored in parameter yet,
         the handler will first try to import it, using the provided value as terraform id.
     :rel provider: The terraform provider for this resource
@@ -69,9 +98,31 @@ entity Resource extends std::PurgeableResource:
     string name
     string? terraform_id = null
     dict config
+    bool manual_config = true
     bool purge_on_delete = false
 end
+
 Resource.provider [1] -- Provider
+"""Relation to the resource provider"""
+
+Resource.root_config [0:1] -- terraform::config::Block
+"""Relation to the root configuration, or null if manual_config is true"""
+
 index Resource(provider, type, name)
 
-implement Resource using std::none
+implement Resource using resourceConfig
+
+implementation resourceConfig for Resource:
+    """
+    If self.manual_config is true, the user should provide the config as a dict
+    directly to the entity.  The root_config relation should then be set to null.
+    If self.manual_config is false, the user should provide the root_config
+    relation, the Block entity will be serialized and attached to this entity
+    config attribute.
+    """
+    if self.manual_config:
+        self.root_config = null
+    else:
+        self.config = self.root_config._config
+    end
+end

--- a/model/config.cf
+++ b/model/config.cf
@@ -1,0 +1,156 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+typedef nesting_mode_t as string matching self in ["set", "list", "dict", "single"]
+"""
+    The nesting mode of a repeated config block.
+"""
+
+
+entity Block:
+    """
+    This entity represents a block of attributes in a terraform module.  It can be used
+    for anyone using the module to build a config.  It is being used by the generator
+    to generate the config of a resource or provider.
+
+    Source for the schema: 
+        https://github.com/inmanta/inmanta-tfplugin/blob/7269bc7d28d751b5dc110161dae29a6209c3fb63/docs/tf_grpc_plugin/proto/inmanta_tfplugin/tfplugin5.proto
+
+        tfplugin5.proto:
+        L81:    message Block {
+        L82:        int64 version = 1;
+        L83:        repeated Attribute attributes = 2;
+        L84:        repeated NestedBlock block_types = 3;
+        L85:        string description = 4;
+        L86:        StringKind description_kind = 5;
+        L87:        bool deprecated = 6;
+        L88:    }
+
+
+    :attr name: The name of this config section in the parent config block.
+    :attr attributes: A dictionary of attributes.  The key is the attribute name
+        as specified in the terraform provider schema.  The value is the value
+        assigned to this attribute in the corresponding inmanta entity.
+    :attr deprecated: If true, will raise a warning everytime the configuration
+        block is used.
+    :attr nesting_model: The nesting mode of this config into the parent one.
+        If it is a list, the key attribute should be set, and will be used to store
+        the different element of the list.  (Siblings of this element)
+        If it is a dict, the key attribute should be set, and will be used to place
+        the element in the dict named after the name of this block.
+    :attr key: The key, required for list and dict nesting mode, ignored otherwise.
+    :attr _config: Generated, the serialized version of this config.
+
+    i.e. The following configuration structure can be constructed with entities.
+
+        .. code-block::
+
+            Block(
+                name="root",
+                attributes={"name": "Albert"},
+                children=[
+                    Block(
+                        name="children",
+                        attributes={"name": "Bob", "age": 12},
+                        nesting_mode="set",
+                    ),
+                    Block(
+                        name="children",
+                        attributes={"name": "Alice", "age": 14},
+                        nesting_mode="set",
+                    ),
+                    Block(
+                        name="pets",
+                        attributes={"type": "dog"},
+                        nesting_mode="dict",
+                        key="Brutus",
+                    ),
+                    Block(
+                        name="favorite_dishes",
+                        attributes={"name": "Pizza"},
+                        nesting_mode="list",
+                        key="1",
+                    ),
+                    Block(
+                        name="favorite_dishes",
+                        attributes={"name": "Pasta"},
+                        nesting_mode="list",
+                        key="2",
+                    )
+                ]
+            )
+
+        It will be serialized as follows:
+
+        .. code-block::
+
+            {
+                "name": "Albert",
+                "children": [
+                    {
+                        "name": "Alice",
+                        "age": 14,
+                    },
+                    {
+                        "name": "Bob",
+                        "age": 12,
+                    },
+                ],
+                "pets": {
+                    "Brutus": {
+                        "type": "dog",
+                    },
+                },
+                "favorite_dishes": [
+                    {"name": "Pizza"},
+                    {"name": "Pasta"},
+                ],
+            }
+    """
+    string name
+    dict attributes
+    bool deprecated = false
+
+    nesting_mode_t nesting_mode = "single"
+    string? key = null
+
+    dict _config
+end
+
+
+Block.parent [0:1] -- Block.children [0:]
+
+
+implementation serialize for Block:
+    """
+    Serialize this block into a config dict.
+    """
+    self._config = serialize_config(self)
+end
+
+
+implementation deprecation_warning for Block:
+    """
+    Send a warning that the usage of this block is deprecated
+    """
+    # TODO
+end
+
+
+implement Block using serialize
+implement Block using deprecation_warning when self.deprecated

--- a/model/config.cf
+++ b/model/config.cf
@@ -149,7 +149,7 @@ implementation deprecation_warning for Block:
     """
     Send a warning that the usage of this block is deprecated
     """
-    # TODO
+    deprecated_config_block(self)
 end
 
 

--- a/model/config.cf
+++ b/model/config.cf
@@ -60,42 +60,43 @@ entity Block:
 
         .. code-block::
 
-            Block(
+            terraform::config::Block(
                 name="root",
                 attributes={"name": "Albert"},
                 children=[
-                    Block(
+                    terraform::config::Block(
                         name="children",
                         attributes={"name": "Bob", "age": 12},
                         nesting_mode="set",
                     ),
-                    Block(
+                    terraform::config::Block(
                         name="children",
                         attributes={"name": "Alice", "age": 14},
                         nesting_mode="set",
                     ),
-                    Block(
+                    terraform::config::Block(
                         name="pets",
                         attributes={"type": "dog"},
                         nesting_mode="dict",
                         key="Brutus",
                     ),
-                    Block(
+                    terraform::config::Block(
                         name="favorite_dishes",
                         attributes={"name": "Pizza"},
                         nesting_mode="list",
                         key="1",
                     ),
-                    Block(
+                    terraform::config::Block(
                         name="favorite_dishes",
                         attributes={"name": "Pasta"},
                         nesting_mode="list",
                         key="2",
                     )
-                ]
+                ],
+                parent=null,
             )
 
-        It will be serialized as follows:
+        It will be serialized as follows (the order of the children list might differ):
 
         .. code-block::
 

--- a/module.yml
+++ b/module.yml
@@ -4,5 +4,5 @@ description:
 license: ASL 2.0
 copyright: 2021 Inmanta
 name: terraform
-version: 1.1.0
+version: 1.2.0
 compiler_version: 2019.3

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -158,7 +158,7 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
     # Build the base dict, containing all the attribute of this block
     d = {k: v for k, v in config_block.attributes.items()}
 
-    sets: Dict[str, Set[Any]] = defaultdict(set)
+    sets: Dict[str, List[Any]] = defaultdict(list)
     lists: Dict[str, Dict[str, Any]] = defaultdict(dict)
     dicts: Dict[str, Dict[str, Any]] = defaultdict(dict)
 
@@ -174,7 +174,7 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
             d[child.name] = child._config
 
         elif child.nesting_mode == "set":
-            sets[child.name].add(child._config)
+            sets[child.name].append(child._config)
 
         elif child.nesting_mode == "list":
             if child.key is None:
@@ -186,7 +186,7 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
                     f"used in {lists[child.name]}"
                 )
 
-            lists[child.name][child.key] = child._dict
+            lists[child.name][child.key] = child._config
 
         elif child.nesting_mode == "dict":
             if child.key is None:
@@ -198,7 +198,7 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
                     f"used in {dicts[child.name]}"
                 )
 
-            dicts[child.name][child.key] = child._dict
+            dicts[child.name][child.key] = child._config
 
         else:
             raise PluginException(f"Uknown nesting type: {child.nesting_mode}")
@@ -227,7 +227,7 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
 
     # Add all the unordered lists (sets) to the config
     for key, s in sets.items():
-        d[key] = list(s)
+        d[key] = s
 
     # Add all the ordered lists to the config
     for key, l in lists.items():

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -157,8 +157,8 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
     """
     Serialize a config block into a dictionnary.
     """
-   for child in config_block.children:
-        # access all required attributes to let the compiler know we need them 
+    for child in config_block.children:
+        # access all required attributes to let the compiler know we need them
         child.name
         child._config
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -16,7 +16,8 @@
     Contact: code@inmanta.com
 """
 import json
-from typing import Dict, Optional
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import inmanta.resources
 from inmanta.config import Config
@@ -147,3 +148,94 @@ def get_resource_attribute_ref(
     :param attribute_path: The path, in the resource state dict, to the desired value.
     """
     return resource_attribute_reference(resource, attribute_path).to_dict()
+
+
+@plugin
+def serialize_config(config_block: "terraform::config::Block") -> "dict":  # type: ignore
+    """
+    Serialize a config block into a dictionnary.
+    """
+    # Build the base dict, containing all the attribute of this block
+    d = {k: v for k, v in config_block.attributes.items()}
+
+    sets: Dict[str, Set[Any]] = defaultdict(set)
+    lists: Dict[str, Dict[str, Any]] = defaultdict(dict)
+    dicts: Dict[str, Dict[str, Any]] = defaultdict(dict)
+
+    # For each children, we pick up the config and attach it to this dict.
+    # Depending on the nesting_mode of the child, the way we attach the config will vary.
+    for child in config_block.children:
+        if child.nesting_mode == "single":
+            if child.name in d:
+                raise PluginException(
+                    f"Key {child.name} is already used in the config: {d}"
+                )
+
+            d[child.name] = child._config
+
+        elif child.nesting_mode == "set":
+            sets[child.name].add(child._config)
+
+        elif child.nesting_mode == "list":
+            if child.key is None:
+                raise PluginException("Nesting type dict requires the key to be set")
+
+            if child.key in lists[child.name]:
+                raise PluginException(
+                    f"Can not set key-value pair {child.key}={child._config} as key is already "
+                    f"used in {lists[child.name]}"
+                )
+
+            lists[child.name][child.key] = child._dict
+
+        elif child.nesting_mode == "dict":
+            if child.key is None:
+                raise PluginException("Nesting type dict requires the key to be set")
+
+            if child.key in dicts[child.name]:
+                raise PluginException(
+                    f"Can not set key-value pair {child.key}={child._config} as key is already "
+                    f"used in {dicts[child.name]}"
+                )
+
+            dicts[child.name][child.key] = child._dict
+
+        else:
+            raise PluginException(f"Uknown nesting type: {child.nesting_mode}")
+
+    # Check for all the dicts we will join that the keys sets don't intersect
+    dict_sets: List[Tuple[str, dict]] = [
+        ("single", d),
+        ("sets", sets),
+        ("lists", lists),
+        ("dicts", dicts),
+    ]
+    for dict_set_name_a, dict_set_a in dict_sets:
+        for dict_set_name_b, dict_set_b in dict_sets:
+            if dict_set_name_a >= dict_set_name_b:
+                # We don't want to compare a set against itself
+                # We don't want to compare sets twice either
+                continue
+
+            intersection = set(dict_set_a.keys()) & set(dict_set_b.keys())
+            if intersection:
+                raise PluginException(
+                    f"The keys {intersection} are present in two part of the config with "
+                    f"unmatching types: {dict_set_name_a}={dict_set_a} "
+                    f"and {dict_set_name_b}={dict_set_b}"
+                )
+
+    # Add all the unordered lists (sets) to the config
+    for key, s in sets.items():
+        d[key] = list(s)
+
+    # Add all the ordered lists to the config
+    for key, l in lists.items():
+        sorted_l = sorted(((k, v) for k, v in l.items()), key=lambda x: x[0])
+        d[key] = [x[1] for x in sorted_l]
+
+    # Add all the dicts to the config
+    for key, dd in dicts.items():
+        d[key] = dd
+
+    return d

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -17,7 +17,7 @@
 """
 import json
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import inmanta.resources
 from inmanta.config import Config

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -157,6 +157,11 @@ def serialize_config(config_block: "terraform::config::Block") -> "dict":  # typ
     """
     Serialize a config block into a dictionnary.
     """
+   for child in config_block.children:
+        # access all required attributes to let the compiler know we need them 
+        child.name
+        child._config
+
     # Build the base dict, containing all the attribute of this block
     d = {k: v for k, v in config_block.attributes.items()}
 

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -1,0 +1,97 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import logging
+
+from pytest_inmanta.plugin import Project
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_config_serialization(project: Project):
+    model = """
+        import terraform::config
+
+        terraform::config::Block(
+            name="root",
+            attributes={"name": "Albert"},
+            children=[
+                terraform::config::Block(
+                    name="children",
+                    attributes={"name": "Bob", "age": 12},
+                    nesting_mode="set",
+                ),
+                terraform::config::Block(
+                    name="children",
+                    attributes={"name": "Alice", "age": 14},
+                    nesting_mode="set",
+                ),
+                terraform::config::Block(
+                    name="pets",
+                    attributes={"type": "dog"},
+                    nesting_mode="dict",
+                    key="Brutus",
+                ),
+                terraform::config::Block(
+                    name="favorite_dishes",
+                    attributes={"name": "Pizza"},
+                    nesting_mode="list",
+                    key="1",
+                    children=[
+                        terraform::config::Block(
+                            name="content",
+                            attributes={"salt": "yes", "sugar": "no"},
+                        ),
+                    ],
+                ),
+                terraform::config::Block(
+                    name="favorite_dishes",
+                    attributes={"name": "Pasta"},
+                    nesting_mode="list",
+                    key="2",
+                )
+            ],
+            parent=null,
+        )
+    """
+    project.compile(model, no_dedent=False)
+
+    blocks = project.get_instances("terraform::config::Block")
+    root_block = next(iter(block for block in blocks if block.name == "root"))
+
+    assert root_block._config["name"] == "Albert"
+    assert root_block._config["pets"] == {
+        "Brutus": {
+            "type": "dog",
+        },
+    }
+    assert root_block._config["favorite_dishes"] == [
+        {"name": "Pizza", "content": {"salt": "yes", "sugar": "no"}},
+        {"name": "Pasta"},
+    ]
+
+    alice = {
+        "name": "Alice",
+        "age": 14,
+    }
+    bob = {
+        "name": "Bob",
+        "age": 12,
+    }
+    assert root_block._config["children"] == [alice, bob] or root_block._config[
+        "children"
+    ] == [bob, alice]

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -17,6 +17,7 @@
 """
 import logging
 import subprocess
+import sys
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 from uuid import UUID
@@ -125,8 +126,7 @@ def test_deprecated_config(project: Project) -> None:
 
     # Compile a second time in a separate process to catch the logs
     result = subprocess.Popen(
-        "python -m inmanta.app -v compile",
-        shell=True,
+        [sys.executable, "-m", "inmanta.app", "-v", "compile"],
         cwd=project._test_project_dir,
         encoding="utf-8",
         text=True,

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -135,9 +135,9 @@ def test_deprecated_config(project: Project) -> None:
     )
     stdout, stderr = result.communicate()
     assert result.returncode == 0, stderr
-    assert (
-        stdout
-        == "inmanta_plugins.terraformWARNING The usage of config 'root' at ./main.cf:3 is deprecated\n"
+    assert stdout == (
+        "inmanta_plugins.terraformWARNING The usage of config 'root' at "
+        f"{project._test_project_dir}/main.cf:3 is deprecated\n"
     )
 
 


### PR DESCRIPTION
# Description

The goal of this PR is to improve the generated modules.  Currently, generated modules build their resource's configs in plugins, with python generated code.  This is ugly, and prone to error, as it is hard to be sure we have sanitized all python reserved keywords from the generated code.  This is the kind of issue that we face: https://github.com/inmanta/terraform-generator/issues/16

In this PR, support is added for a new way of constructing the the config: via a tree of entities, which can then be serialized into a dict.  (Similar to what we do with the `yang::Container` entity)
The preferred way of working for user using only the modules will probably be the simple dict, so this is left untouched, and option is simply added to enable this new way of working, and generated module should start using it.