### PR TITLE
Exclude `grpcio==1.49.0rc1` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 inmanta-tfplugin
 msgpack
 protobuf
-grpcio
+
+# This pre-release is broken as reported here: https://github.com/grpc/grpc/issues/30640
+# The version constraint can be removed once a newer pre-release is published.
+grpcio!=1.49.0rc1


### PR DESCRIPTION
cf. https://github.com/grpc/grpc/issues/30640