### PR TITLE
Issue/fix deprecation warning test (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 1.3.1 - ?
+## 1.3.4 - ?
 - 
+
+## 1.3.3 - 26/10/2022
+- Minor test case improvement
 
 ## 1.3.2 - 24/10/2022
 - Add timeouts on external http requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 1.3.4 - ?
+## 1.3.5 - ?
 - 
+
+## 1.3.4 - 27/10/2022
+- Minor test case improvement
 
 ## 1.3.3 - 26/10/2022
 - Minor test case improvement

--- a/module.yml
+++ b/module.yml
@@ -4,5 +4,5 @@ description:
 license: ASL 2.0
 copyright: 2021 Inmanta
 name: terraform
-version: 1.3.2
+version: 1.3.3
 compiler_version: 2019.3

--- a/module.yml
+++ b/module.yml
@@ -4,5 +4,5 @@ description:
 license: ASL 2.0
 copyright: 2021 Inmanta
 name: terraform
-version: 1.3.3
+version: 1.3.4
 compiler_version: 2019.3

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -141,7 +141,7 @@ def test_deprecated_config(project: Project) -> None:
     assert result.returncode == 0, stderr
 
     warning_regex = re.compile(
-        r"py.warnings              WARNING (.*)/terraform/plugins/__init__.py:469: "
+        r"py.warnings              WARNING (.*)/terraform/plugins/__init__.py:(\d+): "
         r"DeprecationWarning: The usage of config '' at (.*)/main.cf:3 is deprecated"
     )
 

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -141,8 +141,8 @@ def test_deprecated_config(project: Project) -> None:
     assert result.returncode == 0, stderr
 
     warning_regex = re.compile(
-        r"py.warnings              WARNING (.*)/terraform/plugins/__init__.py:(\d+): "
-        r"DeprecationWarning: The usage of config '' at (.*)/main.cf:3 is deprecated"
+        r"py\.warnings\s+WARNING .*\/__init__\.py:\d+: DeprecationWarning: "
+        r"The usage of config '' at .*\/main\.cf:3 is deprecated"
     )
 
     for line in stdout.split("\n"):
@@ -151,7 +151,7 @@ def test_deprecated_config(project: Project) -> None:
     else:
         assert (
             False
-        ), f"Didn't find any line matching {warning_regex.pattern} in compile logs:\n{stdout}"
+        ), f"Didn't find any line matching {repr(warning_regex.pattern)} in compile logs:\n{stdout}"
 
 
 @pytest.mark.terraform_provider_local

--- a/tests/features/test_config_tree.py
+++ b/tests/features/test_config_tree.py
@@ -17,6 +17,7 @@
 """
 import json
 import logging
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -139,22 +140,18 @@ def test_deprecated_config(project: Project) -> None:
     stdout, stderr = result.communicate()
     assert result.returncode == 0, stderr
 
-    desired_logs = {
-        (
-            f"py.warnings              WARNING {project._test_project_dir}/libs/terraform/plugins/__init__.py:469: "
-            f"DeprecationWarning: The usage of config '' at {project._test_project_dir}/main.cf:3 is deprecated"
-        ),
-        (
-            # prior to https://github.com/inmanta/inmanta-core/commit/64798acc8abcc3b7b31ab657f1d04e1974209d6f
-            f"py.warnings              WARNING {project._test_project_dir}/libs/terraform/plugins/__init__.py:469: "
-            "DeprecationWarning: The usage of config '' at ./main.cf:3 is deprecated"
-        ),
-    }
+    warning_regex = re.compile(
+        r"py.warnings              WARNING (.*)/terraform/plugins/__init__.py:469: "
+        r"DeprecationWarning: The usage of config '' at (.*)/main.cf:3 is deprecated"
+    )
 
-    output_lines = set(stdout.split("\n"))
-    assert (
-        output_lines & desired_logs
-    ), f"Didn't find at least one of the expected logs in output: {desired_logs} & {output_lines} = {{}}"
+    for line in stdout.split("\n"):
+        if warning_regex.fullmatch(line):
+            break
+    else:
+        assert (
+            False
+        ), f"Didn't find any line matching {warning_regex.pattern} in compile logs:\n{stdout}"
 
 
 @pytest.mark.terraform_provider_local


### PR DESCRIPTION
# Description

1. Make regex more tolerant to work with v2 and v1 modules.
2. Skip test for version of core who don't support simple warnings yet