### PR TITLE
Issue/more robust tmp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 1.3.5 - ?
-- 
+## 1.3.5 - 07/11/2022
+- Minor test case improvement
 
 ## 1.3.4 - 27/10/2022
 - Minor test case improvement

--- a/module.yml
+++ b/module.yml
@@ -4,5 +4,5 @@ description:
 license: ASL 2.0
 copyright: 2021 Inmanta
 name: terraform
-version: 1.3.4
+version: 1.3.5.dev1667811529
 compiler_version: 2019.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,8 @@
 """
 import logging
 import os
-import shutil
+import typing
 from copy import deepcopy
-from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from uuid import UUID
 
@@ -143,20 +142,23 @@ def lab_config(lab_config_session: Dict[str, Any]) -> dict:
 
 
 @pytest.fixture(scope="session")
-def session_temp_dir(tmpdir_factory: pytest.TempdirFactory) -> str:
+def session_temp_dir(
+    tmpdir_factory: pytest.TempdirFactory,
+) -> typing.Generator[str, None, None]:
     session_temp_dir = tmpdir_factory.mktemp("session")
-    LOGGER.info(f"Session temp dir is: {str(session_temp_dir)}")
+    LOGGER.info(f"Session temp dir is: {session_temp_dir}")
     yield str(session_temp_dir)
-    session_temp_dir.remove(ignore_errors=True)
+    session_temp_dir.remove(ignore_errors=False)
 
 
 @pytest.fixture(scope="function")
-def function_temp_dir(session_temp_dir: str) -> str:
-    function_temp_dir = Path(session_temp_dir) / Path("function")
-    function_temp_dir.mkdir(parents=True, exist_ok=False)
+def function_temp_dir(
+    tmpdir_factory: pytest.TempdirFactory,
+) -> typing.Generator[str, None, None]:
+    function_temp_dir = tmpdir_factory.mktemp("function")
     LOGGER.info(f"Function temp dir is: {function_temp_dir}")
     yield str(function_temp_dir)
-    shutil.rmtree(str(function_temp_dir), ignore_errors=True)
+    function_temp_dir.remove(ignore_errors=False)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,16 +141,6 @@ def lab_config(lab_config_session: Dict[str, Any]) -> dict:
     return deepcopy(lab_config_session)
 
 
-@pytest.fixture(scope="session")
-def session_temp_dir(
-    tmpdir_factory: pytest.TempdirFactory,
-) -> typing.Generator[str, None, None]:
-    session_temp_dir = tmpdir_factory.mktemp("session")
-    LOGGER.info(f"Session temp dir is: {session_temp_dir}")
-    yield str(session_temp_dir)
-    session_temp_dir.remove(ignore_errors=False)
-
-
 @pytest.fixture(scope="function")
 def function_temp_dir(
     tmpdir_factory: pytest.TempdirFactory,


### PR DESCRIPTION
# Description

I didn't find the cause of the delete failure (nor an error giving any hint), so I just made it so that it wouldn't go unnoticed, and that it would make the concerned test failed, instead of all the following one:

- Don't skip failure when failing to delete dir
- Create new folder for each new test function
- Remove unused session fixture
