### PR TITLE
Issue/migrate to pydantic v2

### DIFF
--- a/plugins/states/generational_state_fact.py
+++ b/plugins/states/generational_state_fact.py
@@ -147,7 +147,7 @@ class LegacyStateFact(StateFact):
         return self.state
 
     @classmethod
-    def build_from_state(cls: typing.Type["SF"], state: dict) -> "SF":
+    def build_from_state(cls, state: dict) -> "LegacyStateFact":
         return cls(state=state)
 
     @classmethod

--- a/plugins/states/generational_state_fact.py
+++ b/plugins/states/generational_state_fact.py
@@ -76,7 +76,7 @@
 
             state_fact_generations: typing.Dict[typing.Optional[str], typing.Type[StateFact]] = {
                 ...,
-                BuboGenerationStateFact.generation: BuboGenerationStateFact,
+                BuboGenerationStateFact.generation(): BuboGenerationStateFact,
             }
 
 """

--- a/plugins/states/generational_state_fact.py
+++ b/plugins/states/generational_state_fact.py
@@ -160,21 +160,31 @@ class LegacyStateFact(StateFact):
 
 class GenerationalStateFact(StateFact):
     @classmethod
-    @pydantic.computed_field(alias=STATE_DICT_GENERATION_MARKER)
-    @property
     @abc.abstractmethod
     def generation(cls) -> str:
         """
         Should be implemented by the subclass, and return the generation identifier
         """
 
+    def _iter(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> "pydantic.typing.TupleGenerator":
+        """
+        We overwrite the _iter method simply to add our generation marker to the
+        generated dict or json payload.
+        """
+        for x in super()._iter(*args, **kwargs):
+            yield x
+
+        yield STATE_DICT_GENERATION_MARKER, self.generation()
+
     @classmethod
     def build_from_state(cls: typing.Type["GSF"], state: dict) -> "GSF":
         state_generation = state[STATE_DICT_GENERATION_MARKER]
-        if not state_generation == cls.generation:
+        if not state_generation == cls.generation():
             # Actively check that the state dict is of the correct generation
             raise ValueError(
-                f"Unexpected generation value: {state_generation} != {cls.generation}"
+                f"Unexpected generation value: {state_generation} != {cls.generation()}"
             )
 
         return cls(**state)
@@ -201,8 +211,6 @@ class AlbatrossGenerationStateFact(GenerationalStateFact):
         return self.state
 
     @classmethod
-    @pydantic.computed_field(alias=STATE_DICT_GENERATION_MARKER)
-    @property
     def generation(cls) -> str:
         return "Albatross"
 
@@ -241,7 +249,7 @@ class AlbatrossGenerationStateFact(GenerationalStateFact):
 
 state_fact_generations: typing.Dict[typing.Optional[str], typing.Type[StateFact]] = {
     None: LegacyStateFact,
-    AlbatrossGenerationStateFact.generation: AlbatrossGenerationStateFact,
+    AlbatrossGenerationStateFact.generation(): AlbatrossGenerationStateFact,
 }
 """
 This dict holds all the generations of state dicts which were supported by the module.

--- a/plugins/states/terraform_resource_state_inmanta.py
+++ b/plugins/states/terraform_resource_state_inmanta.py
@@ -144,7 +144,7 @@ class TerraformResourceStateInmanta(TerraformResourceState):
             )  # Make our date timezone-aware
             self._state_fact.config_hash = self.config_hash
 
-        self._param_client.set(self._state_fact.model_dump_json(by_alias=True))
+        self._param_client.set(self._state_fact.json())
 
         self._state = value
 

--- a/plugins/states/terraform_resource_state_inmanta.py
+++ b/plugins/states/terraform_resource_state_inmanta.py
@@ -144,7 +144,7 @@ class TerraformResourceStateInmanta(TerraformResourceState):
             )  # Make our date timezone-aware
             self._state_fact.config_hash = self.config_hash
 
-        self._param_client.set(self._state_fact.json())
+        self._param_client.set(self._state_fact.model_dump_json(by_alias=True))
 
         self._state = value
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,6 +8,11 @@ types-protobuf
 types-requests
 docker
 
+# Pin the version of inmanta-core before the Pydantic V2 migration, as our module
+# doesn't work with it (typing wise, we use deprecated functions) but no-one currently
+# needs the module (on iso7 or anywhere else)
+inmanta-core<11.dev
+
 # This pre-release is broken as reported here: https://github.com/grpc/grpc/issues/30640
 # Also broken here: https://github.com/grpc/grpc/issues/31885
 # The version constraint can be removed once a newer pre-release is published.


### PR DESCRIPTION
# Description

The terraform module doesn't work very well with pydantic v2, and it was too much of an effort to port it compared to the added value (virtually zero as no-one uses it).  So it is now pinned to the latest version of core that used pydantic v1.
